### PR TITLE
Switch to new close action command

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         },
         {
             "key": "cmd+w",
-            "command": "workbench.files.action.closeFile"
+            "command": "workbench.action.closeActiveEditor"
         },
         {
             "key": "cmd+k cmd+b",


### PR DESCRIPTION
This resolves the following warning: [WARN] Command workbench.files.action.closeFile has been removed. You can use workbench.action.closeActiveEditor instead.

See [vscode/Issue 6605](https://github.com/Microsoft/vscode/issues/6605) for details.
