### PR TITLE
Wrong ctrl+alt+up keybinding in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,14 +228,6 @@
                 "when": "editorFocus"
             },
             {
-                "mac": "ctrl+shift+up",
-                "win": "ctrl+alt+up",
-                "linux": "ctrl+alt+up",
-                "key": "ctrl+alt+up",
-                "command": "editor.action.copyLinesUpAction",
-                "when": "editorFocus"
-            },
-            {
                 "mac": "cmd+l",
                 "win": "ctrl+l",
                 "linux": "ctrl+l",


### PR DESCRIPTION
This entry override the one from the default keybinding, but the default one is correct and I don't think the editor.action.copyLinesUpAction command exists in ST (only { "keys": ["ctrl+shift+d"], "command": "duplicate_line" })