### PR TITLE
Replace legacy API for close action

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
                 "win": "ctrl+w",
                 "linux": "ctrl+w",
                 "key": "ctrl+w",
-                "command": "workbench.files.action.closeFile"
+                "command": "workbench.action.closeActiveEditor"
             },
             {
                 "mac": "f5",


### PR DESCRIPTION
Replace `workbench.files.action.closeFile ` with `workbench.action.closeActiveEditor `