### PR TITLE
additional key for close active editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,13 @@
                 "key": "ctrl+k ctrl+down",
                 "command": "workbench.action.closeActiveEditor"
             },
+              {
+                "mac": "cmd+k cmd+j",
+                "win": "ctrl+k ctrl+j",
+                "linux": "ctrl+k ctrl+j",
+                "key": "ctrl+k ctrl+j",
+                "command": "workbench.action.closeActiveEditor"
+            },
             {
                 "mac": "alt+cmd+[",
                 "key": "ctr+shift+[",


### PR DESCRIPTION
Hello,
For someone who accustomed to vim key, I think it's more convenient to use ctrl+k ctrl+j to close the file.
Thank you :)