### PR TITLE
cmd+backspace for delete line

### DIFF
--- a/package.json
+++ b/package.json
@@ -469,6 +469,11 @@
                 "key": "ctrl+k p",
                 "command": "editor.action.marker.prev",
                 "when": "editorFocus"
+            },{
+                "mac": "cmd+backspace",
+                "key": "none",
+                "command": "editor.action.deleteLines",
+                "when": "editorFocus"
             }
         ]
     },


### PR DESCRIPTION
On mac, cmd+backspace is deleting the lines not only the content of the lines.