### PR TITLE
Added shortcuts to move cursor to editor groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -453,6 +453,30 @@
                 "key": "ctrl+k p",
                 "command": "editor.action.marker.prev",
                 "when": "editorFocus"
+            },
+            {
+                "mac": "ctrl+1",
+                "win": "ctrl+1",
+                "linux": "ctrl+1",
+                "key": "ctrl+1",
+                "command": "workbench.action.focusFirstEditorGroup",
+                "when": "editorFocus"
+            },
+            {
+                "mac": "ctrl+2",
+                "win": "ctrl+2",
+                "linux": "ctrl+2",
+                "key": "ctrl+2",
+                "command": "workbench.action.focusSecondEditorGroup",
+                "when": "editorFocus"
+            },
+            {
+                "mac": "ctrl+3",
+                "win": "ctrl+3",
+                "linux": "ctrl+3",
+                "key": "ctrl+3",
+                "command": "workbench.action.focusThirdEditorGroup",
+                "when": "editorFocus"
             }
         ],
         "configuration": {


### PR DESCRIPTION
This change adds keyboard shortcuts to jump cursor to 1st, 2nd and 3rd editor groups.

On all 3 platforms, this makes the shortcut `ctrl+<number>` where `<number>` is 1-3. Based on docs, that's already the default on windows and linux so it felt redundant but I added mappings for those anyways.

