### PR TITLE
Make quick open - enter behave like in Sublime

### DIFF
--- a/package.json
+++ b/package.json
@@ -477,6 +477,13 @@
                 "key": "ctrl+3",
                 "command": "workbench.action.focusThirdEditorGroup",
                 "when": "editorFocus"
+            },
+            {
+                "mac": "cmd+p",
+                "win": "ctrl+p",
+                "linux": "ctrl+p",
+                "key": "ctrl+p",
+                "command": "workbench.action.quickOpenPreviousEditor"
             }
         ],
         "configuration": {


### PR DESCRIPTION
fixes https://github.com/Microsoft/vscode-sublime-keybindings/issues/60