### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -492,7 +492,22 @@
                 "command": "deleteAllRight",
                 "key": "ctrl+k ctrl+k",
                 "when": "editorTextFocus && !editorReadonly"
-            }            
+            },
+            {
+                "mac": "cmd+e",
+                "win": "ctrl+e",
+                "linux": "ctrl+e",
+                "command": "slurp_find_string",
+                "key": "ctrl+e"
+            },
+            {
+                "mac": "cmd+shift+enter",
+                "win": "ctrl+shift+enter",
+                "linux": "ctrl+shift+enter",
+                "keys": "ctrl+shift+enter",
+                "command": "run_macro_file",
+                "args": {"file": "res://Packages/Default/Add Line Before.sublime-macro"}
+            }
         ],
         "configuration": {
             "type": "object",


### PR DESCRIPTION
"ctrl + e": 在HTML中用Tab键可以自动补全标签，但是在jsx的render()中要通过“ctrl+e"
"ctrl + shift + enter": 与”ctrl+enter“对应，不加shift，是在下一行插入，反之在前一行插入