### PR TITLE
Add something close to Expand selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,14 @@
                 "command": "workbench.action.toggleZenMode"
             },
             {
+                "mac": "cmd+shift+a",
+                "win": "ctrl+shift+a",
+                "linux": "ctrl+shift+a",
+                "key": "ctrl+shift+a",
+                "command": "editor.action.smartSelect.grow",
+                "when": "editorTextFocus"
+            },
+            {
                 "mac": "cmd+w",
                 "win": "ctrl+w",
                 "linux": "ctrl+w",


### PR DESCRIPTION
SublimeText has 4 ways to expand a selection, while VS Code has only one. I mapped `CTRL+SHIFT+A` only because `CTRL+SHIFT+SPACE`, `CTRL+SHIFT+M` and `CTRL+SHIF+J` are already taken.