### PR TITLE
Issue 73 - consolidate duplicate keybinding

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "contributes": {
         "keybindings": [
             {
-                "mac": "cmd+shift+ctrl+f",
+                "mac": "ctrl+shift+cmd+f",
                 "win": "shift+f11",
                 "linux": "shift+f11",
                 "key": "shift+f11",
@@ -411,13 +411,6 @@
                 "key": "ctrl+alt+shift+right",
                 "command": "cursorWordEndRightSelect",
                 "when": "editorTextFocus"
-            },
-            {
-                "mac": "cmd+ctrl+shift+f",
-                "win": "shift+f11",
-                "linux": "shift+f11",
-                "key": "shift+f11",
-                "command": "workbench.action.toggleZenMode"
             },
             {
                 "mac": "cmd+j",


### PR DESCRIPTION
Fixes Issue #73.

Keybinding for toggleZenMode was duplicated, using variations "cmd+shift+ctrl+f" and "cmd+ctrl+shift+f". Consolidated to a single instance with "ctrl+shift+cmd+f" (following modifier key sequence most commonly used in Visual Studio Code default keyboard shortcuts).