### PR TITLE
Add missing '>' tags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ We may have missed a keyboard shortcut. If we did please help us out! It is very
 ```json
 {
     "mac": "<keyboard shortcut for mac>",
-    "linux": "<keyboard shortcut for linux",
-    "win": "<keyboard shortcut for windows",
+    "linux": "<keyboard shortcut for linux>",
+    "win": "<keyboard shortcut for windows>",
     "key": "<default keyboard shortcut>",
-    "command": "<name of the command in VS Code"
+    "command": "<name of the command in VS Code>"
 }
 ```
 


### PR DESCRIPTION
The JSON snippet below was missing closing '>' tags for the 
`linux`, `win`, and `command` keys.:

```json
{
    "mac": "<keyboard shortcut for mac>",
    "linux": "<keyboard shortcut for linux",
    "win": "<keyboard shortcut for windows",
    "key": "<default keyboard shortcut>",
    "command": "<name of the command in VS Code"
}
```

This commit includes those missing '>' tags.