### PR TITLE
Don't run Webpack in watch mode during prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "watch": "webpack --watch --info-verbosity verbose --config ./build/node-extension.webpack.config.js",
         "compile-web": "webpack --config ./build/web-extension.webpack.config.js",
         "watch-web": "webpack --watch --info-verbosity verbose --config ./build/web-extension.webpack.config.js",
-        "package-web": "webpack --mode production --watch --config ./build/web-extension.webpack.config.js",
+        "package-web": "webpack --mode production --config ./build/web-extension.webpack.config.js",
         "lint": "tslint -p ./"
     },
     "devDependencies": {


### PR DESCRIPTION
The `package-web` script is executed as part of `vscode:prepublish`. Including the `--watch` argument means the extension cannot be packaged because webpack does not terminate. That argument is already provided with the `watch-web` script.