### PR TITLE
Add ctrl+shift+backspace (deleteAllLeft)

### DIFF
--- a/package.json
+++ b/package.json
@@ -341,6 +341,22 @@
                 "when": "editorFocus"
             },
             {
+                "mac": "ctrl+shift+backspace",
+                "win": "ctrl+shift+backspace",
+                "linux": "ctrl+shift+backspace",
+                "key": "ctrl+shift+backspace",
+                "command": "deleteAllLeft",
+                "when": "editorFocus"
+            },
+            {
+                "mac": "ctrl+shift+delete",
+                "win": "ctrl+shift+delete",
+                "linux": "ctrl+shift+delete",
+                "key": "ctrl+shift+delete",
+                "command": "deleteAllRight",
+                "when": "editorFocus"
+            },
+            {
                 "mac": "ctrl+shift+up",
                 "win": "alt+shift+up",
                 "linux": "alt+shift+up",


### PR DESCRIPTION
From sublime text keymap:
```js
{ "keys": ["ctrl+shift+backspace"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete to Hard BOL.sublime-macro"} },
{ "keys": ["ctrl+shift+delete"], "command": "run_macro_file", "args": {"file": "res://Packages/Default/Delete to Hard EOL.sublime-macro"} },
```