### PR TITLE
fix: update sublime folder finder to support SublimeText from 4.x

### DIFF
--- a/src/sublimeFolderFinder.ts
+++ b/src/sublimeFolderFinder.ts
@@ -6,9 +6,21 @@ import * as fileSystem from './fsWrapper';
 export const sublimeSettingsFilename = 'Preferences.sublime-settings';
 
 const defaultSublimeSettingsPaths: Map<string, string[]> = new Map([
-    ['win32', [path.join(os.homedir(), 'AppData', 'Roaming', 'Sublime Text 3')]],
-    ['darwin', [path.join(os.homedir(), 'Library', 'Application Support', 'Sublime Text 3')]],
-    ['linux', [path.join(os.homedir(), '.config', 'sublime-text-3')]],
+    ['win32', [
+            path.join(os.homedir(), 'AppData', 'Roaming', 'Sublime Text 3'),
+            path.join(os.homedir(), 'AppData', 'Roaming', 'Sublime Text')
+        ]
+    ],
+    ['darwin', [
+            path.join(os.homedir(), 'Library', 'Application Support', 'Sublime Text 3'),
+            path.join(os.homedir(), 'Library', 'Application Support', 'Sublime Text')
+        ]
+    ],
+    ['linux', [
+            path.join(os.homedir(), '.config', 'sublime-text-3'),
+            path.join(os.homedir(), '.config', 'sublime-text')
+        ]
+    ],
 ]);
 
 const settingsSubfoldersPath = path.join('Packages', 'User', 'Preferences.sublime-settings');


### PR DESCRIPTION
## What changed

Former:

The plugin detect `Sublime Text 3/Packages/Preferences.sublime-settings` for Sublime Text settings.

Updated:

I changed this plugins for detecting both `Sublime Text 3/Packages/Preferences.sublime-settings` and `Sublime Text/Packages/Preferences.sublime-settings` for any existing SublimeText setting file.

## Why

As for Sublime Text 4, it is named to `Sublime Text`. As a result, the settings file is located in `Sublime Text` folder rather than `Sublime Text 3`.