### PR TITLE
Add Ctrl+Cmd+P: Quick switch project

### DIFF
--- a/package.json
+++ b/package.json
@@ -585,6 +585,13 @@
                 "command": "editor.action.smartSelect.grow",
                 "key": "ctrl+shift+space",
                 "when": "editorTextFocus"
+            },
+            {
+                "mac": "ctrl+cmd+p",
+                "win": "ctrl+alt+p",
+                "linux": "ctrl+alt+p",
+                "key": "ctrl+alt+p",
+                "command": "workbench.action.openRecent"
             }
         ]
     }


### PR DESCRIPTION
This PR adds the key binding `Ctrl+Cmd+P` as equivalent to open recent project in vscode with `workbench.action.openRecent`

Sublime: `Ctrl+Cmd+P`
<img width="393" alt="Screen Shot 2022-11-03 at 20 35 37" src="https://user-images.githubusercontent.com/5253209/199735294-0657d661-64bb-481c-9327-02ff7aa29cad.png">
Vscode: default `Ctrl+R`

<img width="640" alt="Screen Shot 2022-11-03 at 20 36 23" src="https://user-images.githubusercontent.com/5253209/199735307-d3ea6d98-9309-43a9-b924-86ef7f7b2960.png">
