### PR TITLE
Add mappings: highlight_modified_tabs and show_minimap

### DIFF
--- a/settings/mappings.json
+++ b/settings/mappings.json
@@ -211,7 +211,9 @@
         "Vietnamese (Windows 1258)": {
             "files.encoding": "windows1258"
         }
-    }
+    },
+    "highlight_modified_tabs": "workbench.editor.highlightModifiedTabs", // Boolean
+    "show_minimap": "editor.minimap.enabled" // Boolean
     // "folder_exclude_patterns": "files.exclude",
     // "file_exclude_patterns": "files.exclude",
     // "color_scheme": "workbench.colorTheme",
@@ -220,4 +222,5 @@
     // "caret_style": "editor.cursorBlinking",
     // "auto_complete": "editor.quickSuggestions",
     // "find_selected_text": "autoFindInSelection", // Boolean
+    // "translate_tabs_to_spaces": "editor.insertSpaces", // Boolean
 }


### PR DESCRIPTION
This PR adds two mappings:
- highlight_modified_tabs => workbench.editor.highlightModifiedTabs
  - <img width="191" alt="Screen Shot 2022-11-03 at 20 48 51" src="https://user-images.githubusercontent.com/5253209/199738115-2403e729-3e7c-4657-aaca-2eb89c74afb6.png">
  - <img width="122" alt="Screen Shot 2022-11-03 at 20 48 39" src="https://user-images.githubusercontent.com/5253209/199738111-80ef1400-e1a2-4daf-b16f-7b4e1b02e5bd.png">

- show_minimap => editor.minimap.enabled

Umm, I found `translate_tabs_to_spaces` as well but it turns out vscode handles it really well with the language convention, so I think it is better to comment it out with mapping 🙏🏼 .

