### PR TITLE
Enables full untrusted workspace support

### DIFF
--- a/package.json
+++ b/package.json
@@ -586,5 +586,10 @@
                 "when": "editorTextFocus"
             }
         ]
+    },
+    "capabilities": {
+        "untrustedWorkspaces": {
+        "supported": true
     }
+}
 }


### PR DESCRIPTION
A basic binding extension should work even if you don't trust a workspace.