### PR TITLE
Fix ctrl/cmd+shift+d shortcut when text is selected

### DIFF
--- a/package.json
+++ b/package.json
@@ -289,7 +289,7 @@
                 "win": "ctrl+shift+d",
                 "linux": "ctrl+shift+d",
                 "key": "ctrl+shift+d",
-                "command": "editor.action.copyLinesDownAction",
+                "command": "editor.action.duplicateSelection",
                 "when": "editorFocus"
             },
             {


### PR DESCRIPTION
In Sublime Text, when no text is selected and you hit Ctrl+Shift+D, it duplicates the line.
In Sublime Text, when text is selected and you hit Ctrl+Shift+D, it duplicates the selected text.

This PR changes the command so that VS Code behaves the same way.

Sublime:
![3bb99225-7c99-4d35-b50f-314074a16919](https://github.com/user-attachments/assets/560ef2bb-3518-4cd7-a12a-983f6d874eca)


VS Code Before:
![23701bb1-cd62-4989-8f8d-27d719fa7d79](https://github.com/user-attachments/assets/6a9d335e-7986-4f57-bfee-e23a77c2a766)


VS Code After:
![8c221045-9613-4e98-adbb-274f00c8c2fb](https://github.com/user-attachments/assets/4c4fe8fd-1f85-4937-8eec-065789fd173b)
